### PR TITLE
Replace Results.* with TypedResults.* for improved consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Follow these simple steps to get started:
        private static async Task<IResult> FullCase([FromBody] FullDto dto,
            HttpHandler<FullDto, FullOutDto> handler,
            CancellationToken cancellationToken)
-           => await handler.HandleAsync(dto, cancellationToken, _ => Results.NoContent());
+           => await handler.HandleAsync(dto, cancellationToken, _ => TypedResults.NoContent());
    ```
 
 3. **Register Your Dependencies**  

--- a/src/DotEmilu.AspNetCore/HttpHandler.cs
+++ b/src/DotEmilu.AspNetCore/HttpHandler.cs
@@ -13,7 +13,7 @@ public class HttpHandler<TRequest>(IHandler<TRequest> handler, IVerifier<TReques
             if (!verifier.IsValid)
                 return presenter.ValidationError(verifier.Errors);
 
-            return result is not null ? result.Invoke() : Results.Ok();
+            return result is not null ? result.Invoke() : TypedResults.Ok();
         }
         catch (Exception e)
         {

--- a/src/DotEmilu.AspNetCore/IPresenter.cs
+++ b/src/DotEmilu.AspNetCore/IPresenter.cs
@@ -2,7 +2,7 @@ namespace DotEmilu.AspNetCore;
 
 public interface IPresenter
 {
-    IResult Success<TResponse>(in TResponse response) => Results.Ok(response);
+    IResult Success<TResponse>(in TResponse response) => TypedResults.Ok(response);
     IResult ValidationError(in IEnumerable<ValidationFailure> validationFailures);
     IResult ServerError(in Exception exception);
 }

--- a/tests/DotEmilu.UseCaseTest/Endpoints/TestEndpoint.cs
+++ b/tests/DotEmilu.UseCaseTest/Endpoints/TestEndpoint.cs
@@ -31,7 +31,7 @@ public static class MapEndpoint
         CancellationToken cancellationToken)
     {
         await handler.HandleAsync(dto, cancellationToken);
-        return Results.Ok(verifier.Errors);
+        return TypedResults.Ok(verifier.Errors);
     }
 
     private static async Task<IResult> InOutCase([FromBody] InOutDto dto,
@@ -41,16 +41,16 @@ public static class MapEndpoint
     {
         var response = await handler.HandleAsync(dto, cancellationToken);
         if (!verifier.IsValid)
-            return Results.BadRequest(verifier.Errors);
+            return TypedResults.BadRequest(verifier.Errors);
 
-        return Results.Ok(response);
+        return TypedResults.Ok(response);
     }
 
     [Obsolete("Use AsDelegate.ForAsync<T>")]
     private static async Task<IResult> InHandlerCase([FromBody] InHandlerDto dto,
         HttpHandler<InHandlerDto> handler,
         CancellationToken cancellationToken)
-        => await handler.HandleAsync(dto, cancellationToken, Results.NoContent);
+        => await handler.HandleAsync(dto, cancellationToken, TypedResults.NoContent);
 
     [Obsolete("Use AsDelegate.ForAsync<T, TResponse>")]
     private static async Task<IResult> InOutHandlerCase([FromBody] InOutHandlerDto dto,
@@ -61,5 +61,5 @@ public static class MapEndpoint
     private static async Task<IResult> FullCase([FromBody] FullDto dto,
         HttpHandler<FullDto, FullOutDto> handler,
         CancellationToken cancellationToken)
-        => await handler.HandleAsync(dto, cancellationToken, _ => Results.NoContent());
+        => await handler.HandleAsync(dto, cancellationToken, _ => TypedResults.NoContent());
 }


### PR DESCRIPTION
Updated all usages of `Results.Ok`, `Results.BadRequest`, and `Results.NoContent` to their `TypedResults` equivalents to ensure consistency with recommended ASP.NET Core practices. This change aims to improve readability and maintainability of the codebase.