### PR TITLE
refactor: create reusable Build & Test workflow and update CI configurations

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -34,13 +34,27 @@ release.
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-### Three workflows
+### Workflow files
 
 | Workflow | Trigger | What it does | Destination |
 |---|---|---|---|
-| **CI** | PR to `main` (with relevant changes) | Dependency Review + Build + Test + Coverage (Codecov) + Pack validation | None (validation only) |
-| **Publish Pre-release** | Push/merge to `main` (with relevant changes) | Build + Test + Pack + Push | GitHub Packages |
+| **Build & Test** | Called by CI and Publish Pre-release | Build + Test + Coverage (Codecov) + Pack + Upload artifact | Internal (reusable workflow) |
+| **CI** | PR to `main` (with code/test/build changes) | Dependency Review + Build & Test | None (validation only) |
+| **Publish Pre-release** | Push/merge to `main` (with package-impacting changes) | Build & Test + Push `.nupkg` | GitHub Packages |
 | **Publish Release** | Push of tag `v*` | Build + Test + Pack + Attest provenance + Push + GitHub Release | NuGet.org (stable) or GitHub Packages (pre-release) |
+
+`Build & Test` is a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows)
+that eliminates duplication. It builds, tests with coverage, packs all projects,
+uploads packages as an artifact, and exports the computed version as an output.
+Downstream jobs only need to download the artifact and push — no redundant builds.
+
+CI triggers on `src/**`, `tests/**`, and build config files.
+Publish Pre-release triggers on `src/**`, `assets/icon.jpg`, and build config
+files — but **not** `tests/**`, because test-only changes do not affect the
+package binary.
+
+> **Symbol packages (`.snupkg`):** Only NuGet.org supports `.snupkg`. GitHub
+> Packages does not. Symbol packages are published only during stable releases.
 
 ---
 
@@ -153,15 +167,18 @@ git add . && git commit -m "feat: add batch handler support"
 git push -u origin feature/add-new-handler
 # → On GitHub, open the PR to main
 
-# 4. CI runs automatically (build + test)
+# 4. CI runs automatically (build + test + coverage)
 #    If it passes, you can merge
 
-# 5. On merge/push to main → pre-release is published automatically
+# 5. On merge/push to main:
+#    - If your merge changed src/ or build config → pre-release is published
+#    - If your merge only changed tests/ → no package is published
 #    Version: 10.0.0-alpha.0.81 (example)
 #    Destination: GitHub Packages
 ```
 
-**You do not need to do anything else.** The pre-release publishes itself.
+**You do not need to do anything else.** The pre-release publishes itself when
+package-impacting files change.
 
 ### Scenario 2: Publish a stable release
 
@@ -323,17 +340,17 @@ No additional setup required for GitHub Packages.
 
 ### Codecov — code coverage reporting
 
-CI uploads coverage reports to [Codecov](https://codecov.io) after every PR.
-If `CODECOV_TOKEN` is not configured, the upload is skipped silently
-(`fail_ci_if_error: false`) — CI will still pass.
+Coverage reports are uploaded to [Codecov](https://codecov.io) from the
+`build-and-test.yml` reusable workflow, which is called by both **CI** and
+**Publish Pre-release**.
 
-**One-time setup:**
+Both workflows use `fail_ci_if_error: false`, so a Codecov outage will never
+block builds or publications.
 
-1. Go to https://codecov.io and log in with GitHub
-2. Add the `DotEmilu` repository
-3. Copy the upload token
-4. In your repo: **Settings → Secrets and variables → Actions → New secret**
-   - Name: `CODECOV_TOKEN`, Value: the token
+`CODECOV_TOKEN` is optional when your Codecov organization allows tokenless
+uploads for public repositories. If token authentication is required in the
+future, create a repo secret named `CODECOV_TOKEN` and both workflows will
+use it automatically.
 
 Coverage thresholds are configured in [`codecov.yml`](../codecov.yml) (project
 target, patch target, and flag settings). No repository variables are needed.
@@ -510,11 +527,14 @@ Only `CI` has `workflow_dispatch`. The publish workflows trigger exclusively fro
 their defined triggers (push to main / push of tag). This is intentional to
 prevent accidental publications.
 
-### What happens if a merge to main does not change files in `src/`?
+### What happens if a merge to main only changes tests?
 
-`Publish Pre-release` does not trigger. Only changes in `src/**`, `tests/**`,
-`Directory.Build.props`, `Directory.Packages.props`, `global.json`, `nuget.config`,
-or the workflow file itself activate publishing.
+`Publish Pre-release` does not trigger. Test-only changes do not affect the
+package binary. CI already validated the tests during the PR.
+
+Only changes in `src/**`, `assets/icon.jpg`, `Directory.Build.props`,
+`Directory.Packages.props`, `global.json`, `nuget.config`, or the workflow
+files themselves activate pre-release publishing.
 
 ### Can I have different versions per project?
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,96 @@
+name: Build & Test
+
+on:
+  workflow_call:
+    outputs:
+      version:
+        description: 'MinVer computed package version'
+        value: ${{ jobs.build-and-test.outputs.version }}
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0   # MinVer needs full history to calculate version
+          filter: tree:0   # treeless clone for better performance
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5.2.0
+        with:
+          dotnet-version: '10.x'
+          cache: true                                    # Caches NuGet global-packages folder
+          cache-dependency-path: '**/packages.lock.json' # Required: lock files are in subdirectories
+
+      - name: Restore
+        run: dotnet restore DotEmilu.slnx --locked-mode
+
+      - name: Build
+        run: dotnet build DotEmilu.slnx --no-restore -c Release
+
+      - name: Extract computed version
+        id: version
+        run: |
+          VERSION=$(dotnet msbuild src/DotEmilu/DotEmilu.csproj -target:MinVer -getProperty:PackageVersion -p:Configuration=Release -nologo)
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "MinVer computed version: $VERSION"
+          echo "### MinVer version: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Test
+        run: |
+          dotnet test --solution DotEmilu.slnx --no-build -c Release \
+            --coverlet \
+            --coverlet-output-format cobertura \
+            --coverlet-include "[DotEmilu*]*" \
+            --coverlet-exclude "[DotEmilu.*Tests*]*" \
+            --coverlet-exclude "[DotEmilu.Samples*]*" \
+            --coverlet-exclude-by-attribute "GeneratedCodeAttribute" \
+            --coverlet-skip-auto-props
+
+      - name: Upload unit test coverage
+        uses: codecov/codecov-action@v6.0.0
+        with:
+          directory: tests/DotEmilu.UnitTests/
+          flags: unittests
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload integration test coverage
+        uses: codecov/codecov-action@v6.0.0
+        with:
+          directory: tests/DotEmilu.IntegrationTests/
+          flags: integrationtests
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Pack
+        run: |
+          for proj in src/*/*.csproj; do
+            dotnet pack "$proj" --no-build -c Release -o ./nupkgs
+          done
+          echo "All src/ projects packed successfully."
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: nupkgs
+          path: ./nupkgs/
+          if-no-files-found: error
+          retention-days: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'global.json'
       - 'nuget.config'
       - '.github/workflows/ci.yml'
+      - '.github/workflows/build-and-test.yml'
   # Allows re-running CI manually from the Actions tab (useful for flaky failures)
   workflow_dispatch:
 
@@ -18,11 +19,6 @@ on:
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
-env:
-  DOTNET_NOLOGO: true
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-  DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 permissions: {}   # deny all by default; each job grants only what it needs
 
@@ -45,69 +41,5 @@ jobs:
 
   build-and-test:
     name: Build & Test
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0   # MinVer needs full history to calculate version
-          filter: tree:0   # treeless clone for better performance
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5.2.0
-        with:
-          dotnet-version: '10.x'
-          cache: true                                    # Caches NuGet global-packages folder
-          cache-dependency-path: '**/packages.lock.json' # Required: lock files are in subdirectories
-
-      - name: Restore
-        run: dotnet restore DotEmilu.slnx --locked-mode
-
-      - name: Build
-        run: dotnet build DotEmilu.slnx --no-restore -c Release
-
-      - name: Display computed version
-        run: |
-          VERSION=$(dotnet msbuild src/DotEmilu/DotEmilu.csproj -target:MinVer -getProperty:PackageVersion -p:Configuration=Release -nologo)
-          echo "MinVer computed version: $VERSION"
-          echo "### MinVer version: \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Test
-        run: |
-          dotnet test --solution DotEmilu.slnx --no-build -c Release \
-            --coverlet \
-            --coverlet-output-format cobertura \
-            --coverlet-include "[DotEmilu*]*" \
-            --coverlet-exclude "[DotEmilu.*Tests*]*" \
-            --coverlet-exclude "[DotEmilu.Samples*]*" \
-            --coverlet-exclude-by-attribute "GeneratedCodeAttribute" \
-            --coverlet-skip-auto-props
-
-      - name: Upload unit test coverage
-        uses: codecov/codecov-action@v6.0.0
-        with:
-          directory: tests/DotEmilu.UnitTests/
-          flags: unittests
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload integration test coverage
-        uses: codecov/codecov-action@v6.0.0
-        with:
-          directory: tests/DotEmilu.IntegrationTests/
-          flags: integrationtests
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Validate all projects are packable
-        run: |
-          for proj in src/*/*.csproj; do
-            dotnet pack "$proj" --no-build -c Release -o ./nupkgs-ci
-          done
-          echo "All src/ projects packed successfully."
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,7 @@ jobs:
 
   build-and-test:
     name: Build & Test
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-and-test.yml
     secrets: inherit

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -23,6 +23,8 @@ permissions: {}   # deny all by default; each job grants only what it needs
 jobs:
   build-and-test:
     name: Build & Test
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-and-test.yml
     secrets: inherit
 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -5,85 +5,55 @@ on:
     branches: [ main ]
     paths:
       - 'src/**'
-      - 'tests/**'
+      - 'assets/icon.jpg'
       - 'Directory.Build.props'
       - 'Directory.Packages.props'
       - 'global.json'
       - 'nuget.config'
       - '.github/workflows/publish-prerelease.yml'
+      - '.github/workflows/build-and-test.yml'
 
 # Only one pre-release pipeline per branch at a time
 concurrency:
   group: publish-prerelease-${{ github.ref }}
   cancel-in-progress: false   # Let the running publish finish; queue the next
 
-env:
-  DOTNET_NOLOGO: true
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-  DOTNET_CLI_TELEMETRY_OPTOUT: true
-
 permissions: {}   # deny all by default; each job grants only what it needs
 
 jobs:
-  publish-prerelease:
-    name: Pack & Push to GitHub Packages
+  build-and-test:
+    name: Build & Test
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit
+
+  publish:
+    name: Push to GitHub Packages
+    needs: build-and-test
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
       packages: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-        with:
-          fetch-depth: 0   # MinVer needs full history to calculate version
-          filter: tree:0   # treeless clone for better performance
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5.2.0
-        with:
-          dotnet-version: '10.x'
-          cache: true
-          cache-dependency-path: '**/packages.lock.json'
-
-      - name: Restore
-        run: dotnet restore DotEmilu.slnx --locked-mode
-
-      - name: Build
-        run: dotnet build DotEmilu.slnx --no-restore -c Release
-
-      - name: Test
-        run: dotnet test --solution DotEmilu.slnx --no-build -c Release
-
-      - name: Extract computed package version
-        id: version
-        run: |
-          VERSION=$(dotnet msbuild src/DotEmilu/DotEmilu.csproj -target:MinVer -getProperty:PackageVersion -p:Configuration=Release -nologo)
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Verify version is pre-release
-        if: ${{ !contains(steps.version.outputs.VERSION, '-') }}
+        if: ${{ !contains(needs.build-and-test.outputs.version, '-') }}
         run: |
-          echo "::notice::Version ${{ steps.version.outputs.VERSION }} is stable — skipping pre-release publish."
+          echo "::notice::Version ${{ needs.build-and-test.outputs.version }} is stable — skipping pre-release publish."
           echo "Stable versions are published via publish-release.yml when you push a tag."
           echo "SKIP_PUBLISH=true" >> "$GITHUB_ENV"
 
-      - name: Pack
+      - name: Download packages
         if: ${{ env.SKIP_PUBLISH != 'true' }}
-        run: |
-          for proj in src/*/*.csproj; do
-            dotnet pack "$proj" --no-build -c Release -o ./nupkgs
-          done
-
-      - name: Upload packages as artifact
-        if: ${{ env.SKIP_PUBLISH != 'true' }}
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
-          name: nupkgs-prerelease-${{ steps.version.outputs.VERSION }}
-          path: ./nupkgs/
-          if-no-files-found: error
-          retention-days: 3
+          name: nupkgs
+          path: ./nupkgs
+
+      - name: Setup .NET
+        if: ${{ env.SKIP_PUBLISH != 'true' }}
+        uses: actions/setup-dotnet@v5.2.0
+        with:
+          dotnet-version: '10.x'
 
       - name: Push to GitHub Packages
         if: ${{ env.SKIP_PUBLISH != 'true' }}
@@ -98,5 +68,5 @@ jobs:
         run: |
           echo "### 📦 Pre-release published" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Version:** \`${{ steps.version.outputs.VERSION }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** \`${{ needs.build-and-test.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "**Registry:** [GitHub Packages](https://github.com/renzojared/DotEmilu/packages)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -222,7 +222,7 @@ jobs:
     name: Create GitHub Release
     needs: [build, push-nuget, push-github-packages]
     # Waits for whichever push job ran (the other is always skipped).
-    # Stable:      push-nuget must succeed,        push-github-packages is skipped.
+    # Stable:      push-nuget must succeed, push-github-packages is skipped.
     # Pre-release: push-github-packages must succeed, push-nuget is skipped.
     if: ${{ always() && needs.build.result == 'success' && (needs.push-nuget.result == 'success' || needs.push-nuget.result == 'skipped') && (needs.push-github-packages.result == 'success' || needs.push-github-packages.result == 'skipped') }}
     runs-on: ubuntu-latest
@@ -240,6 +240,12 @@ jobs:
       - name: Build release body
         run: |
           VERSION="${{ needs.build.outputs.version }}"
+          if echo "$VERSION" | grep -q '-'; then
+            PACKAGE_REGISTRY_TEXT="📦 [GitHub Packages](https://github.com/renzojared/DotEmilu/packages)"
+          else
+            PACKAGE_REGISTRY_TEXT="📦 [NuGet.org packages](https://www.nuget.org/profiles/renzojared)"
+          fi
+
           {
             echo "## Installation"
             echo ""
@@ -251,7 +257,7 @@ jobs:
             done
             echo '```'
             echo ""
-            echo "📦 [NuGet.org packages](https://www.nuget.org/profiles/renzojared)"
+            echo "$PACKAGE_REGISTRY_TEXT"
           } > release_body.md
 
       - name: Create GitHub Release

--- a/docs/guides/coverage-configuration.md
+++ b/docs/guides/coverage-configuration.md
@@ -7,7 +7,7 @@ Personal reference for coverage tooling decisions in DotEmilu.
 | Tool | Package | Role |
 |---|---|---|
 | coverlet.MTP | `coverlet.MTP 8.0.1` | Code coverage collection (MTP-native) |
-| Codecov | `codecov/codecov-action@v5` | Upload, threshold enforcement, PR comments |
+| Codecov | `codecov/codecov-action@v6.0.0` | Upload, threshold enforcement, PR comments |
 | codecov.yml | repo root | Codecov server-side config |
 
 ## coverlet.MTP CLI Options
@@ -68,7 +68,10 @@ Personal reference for coverage tooling decisions in DotEmilu.
 | `parsers` | Auto-detection works for Cobertura |
 | `fixes` | No path mapping needed |
 
-## Codecov Action (CI Workflow)
+## Codecov Action (Build & Test reusable workflow)
+
+Coverage is uploaded from the `build-and-test.yml` reusable workflow, which is
+called by both **CI** (PR validation) and **Publish Pre-release** (main branch).
 
 ### Used
 

--- a/src/DotEmilu.AspNetCore/IPresenter.cs
+++ b/src/DotEmilu.AspNetCore/IPresenter.cs
@@ -6,6 +6,7 @@ namespace DotEmilu.AspNetCore;
 public interface IPresenter
 {
     /// <summary>Creates a successful HTTP result with the provided response payload.</summary>
+    /// <remarks>The default implementation returns HTTP 200 (OK).</remarks>
     /// <typeparam name="TResponse">The type of the response.</typeparam>
     /// <param name="response">The response payload.</param>
     /// <returns>An HTTP result representing success.</returns>


### PR DESCRIPTION
## Description

Refactors the GitHub Actions pipeline by extracting the shared build, test, coverage, versioning, and pack logic into a reusable `Build & Test` workflow.

This PR updates the CI and pre-release publishing workflows to consume that reusable workflow, avoids rebuilding packages before publishing, narrows pre-release triggers to package-impacting changes only, and updates the release/coverage documentation to reflect the new pipeline behavior.

Additionally, this PR includes a small XML documentation update in `DotEmilu.AspNetCore` to clarify that the default `IPresenter.Success<TResponse>` implementation returns `HTTP 200 (OK)`, which also gives us a minimal `src/**` change to exercise the updated workflow paths.

Additional adjustments:
- pre-release publishing now reuses packaged artifacts produced by the shared workflow
- CI and pre-release workflows now react to changes in the reusable workflow file
- GitHub Release notes now point to the correct package registry depending on whether the version is stable or pre-release
- release and coverage docs were updated to document the new workflow architecture and Codecov usage

Closes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Build / CI change

## Checklist

- [x] My code follows the existing code style
- [ ] I have run `dotnet build DotEmilu.slnx -c Release` with no warnings
- [ ] I have added/updated tests that prove my fix or feature works
- [ ] All tests pass locally (`dotnet test --solution DotEmilu.slnx -c Release`)
- [x] I have updated documentation if needed (README, XML docs, guides)
