### PR TITLE
docs: clarify release process for immutable GitHub releases

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -41,7 +41,7 @@ release.
 | **Build & Test** | Called by CI and Publish Pre-release | Build + Test + Coverage (Codecov) + Pack + Upload artifact | Internal (reusable workflow) |
 | **CI** | PR to `main` (with code/test/build changes) | Dependency Review + Build & Test | None (validation only) |
 | **Publish Pre-release** | Push/merge to `main` (with package-impacting changes) | Build & Test + Push `.nupkg` | GitHub Packages |
-| **Publish Release** | Push of tag `v*` | Build + Test + Pack + Attest provenance + Push + GitHub Release | NuGet.org (stable) or GitHub Packages (pre-release) |
+| **Publish Release** | Push of tag `v*` | Build + Test + Pack + Attest provenance + Push + GitHub Release (draft → publish) | NuGet.org (stable) or GitHub Packages (pre-release) |
 
 `Build & Test` is a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows)
 that eliminates duplication. It builds, tests with coverage, packs all projects,
@@ -197,7 +197,9 @@ git push --tags
 #   - Validates that MinVer calculates 10.0.0 (must match the tag)
 #   - Publishes .nupkg and .snupkg to NuGet.org
 #   - Calculates stable changelog base (skips pre-releases)
-#   - Creates immutable GitHub Release with notes and artifacts
+#   - Creates GitHub Release as draft, uploads .nupkg assets,
+#     then publishes (required for immutable releases)
+#   - Stable releases are marked as "Latest"
 ```
 
 ### Scenario 3: Publish a beta/RC version by tag
@@ -215,8 +217,9 @@ git push --tags
 # → Publish Release triggers:
 #   - MinVer calculates 10.0.0-beta.1
 #   - Publishes to GitHub Packages (not NuGet.org)
-#   - Computes changelog incrementally from previous RC
-#   - Creates GitHub Release marked as pre-release
+#   - Creates GitHub Release as draft, uploads .nupkg assets,
+#     then publishes (required for immutable releases)
+#   - Marked as pre-release, NOT marked as "Latest"
 ```
 
 ### Scenario 4: Promote a beta to stable
@@ -300,6 +303,25 @@ In `publish-release.yml`, before packing, it is verified that the version MinVer
 computes matches exactly the version in the tag across all projects under `src/`.
 If they do not match, the workflow fails with a clear error. This prevents a tag
 placed on the wrong commit from publishing an unexpected version.
+
+### 6. Immutable releases + draft-then-publish
+
+The repository has [immutable releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
+enabled. Once a release is published, its assets cannot be modified. The workflow
+handles this by:
+
+1. Creating the release as a **draft** (`draft: true`) via `softprops/action-gh-release`
+2. Uploading all `.nupkg` assets while still in draft state
+3. Publishing the release with `gh release edit --draft=false --verify-tag`
+
+Additional safeguards in the release step:
+
+- **`fail_on_unmatched_files: true`** — the workflow fails if the `.nupkg` glob
+  matches no files, preventing an empty release
+- **`make_latest`** — only stable releases are marked as "Latest"; pre-releases
+  are explicitly set to `false`
+- **`--verify-tag`** — `gh release edit` aborts if the tag does not exist in the
+  remote, as an extra safety check
 
 ---
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -275,7 +275,7 @@ jobs:
           echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
           echo "Determined previous stable tag: $PREVIOUS_TAG"
 
-      - name: Create GitHub Release
+      - name: Create GitHub Release (draft)
         uses: softprops/action-gh-release@v2.6.1
         with:
           tag_name: ${{ github.ref_name }}
@@ -285,9 +285,9 @@ jobs:
           prerelease: ${{ contains(needs.build.outputs.version, '-') }}
           body_path: release_body.md
           files: ./nupkgs/*.nupkg
+          fail_on_unmatched_files: true
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2.6.1
-        with:
-          tag_name: ${{ github.ref_name }}
-          prerelease: ${{ contains(needs.build.outputs.version, '-') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false --verify-tag


### PR DESCRIPTION
## Description

Fix asset upload failure on immutable-release repositories by creating the
GitHub Release as a draft first, uploading all `.nupkg` assets, then publishing
via `gh release edit --draft=false`.

Also updated `RELEASE.md` with the new strategy and marked the `gh release edit`
TODO item as completed.

Closes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Build / CI change

## Checklist

- [x] My code follows the existing code style
- [x] I have run `dotnet build DotEmilu.slnx -c Release` with no warnings
- [ ] I have added/updated tests that prove my fix or feature works
- [x] All tests pass locally (`dotnet test --solution DotEmilu.slnx -c Release`)
- [x] I have updated documentation if needed (README, XML docs, guides)
