### PR TITLE
fix: always checkout repo for gh release edit

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -231,9 +231,8 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout repository (for tag calculations)
+      - name: Checkout repository
         uses: actions/checkout@v6.0.2
-        if: ${{ !contains(needs.build.outputs.version, '-') }}
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Description

Fix `gh release edit` command failure by ensuring git is always available.

Remove conditional checkout that was preventing pre-releases from having
access to the `.git` directory. The `gh release edit` command requires git
to be present regardless of version type (stable or pre-release).

Closes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Build / CI change

## Checklist

- [x] My code follows the existing code style
- [x] I have run `dotnet build DotEmilu.slnx -c Release` with no warnings
- [ ] I have added/updated tests that prove my fix or feature works
- [x] All tests pass locally (`dotnet test --solution DotEmilu.slnx -c Release`)
- [ ] I have updated documentation if needed (README, XML docs, guides)
