### PR TITLE
ci: use NuGet/login@v1 for Trusted Publishing and remove hardcoded owner

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,20 +1,17 @@
 # CI/CD & Release Workflow
 
-Complete guide on how the DotEmilu CI/CD pipeline works, how MinVer
-calculates versions, and what you as a developer need to do for each type of
-release.
+How the DotEmilu CI/CD pipeline works, how MinVer calculates versions, and what
+to do for each type of release.
 
 ---
 
 ## Table of contents
 
 - [Workflow architecture](#workflow-architecture)
-- [How MinVer works (your versioning system)](#how-minver-works-your-versioning-system)
+- [How MinVer works](#how-minver-works)
 - [Distribution strategy](#distribution-strategy)
-- [What you need to do: step-by-step scenarios](#what-you-need-to-do-step-by-step-scenarios)
-- [How overwriting already-published versions is prevented](#how-overwriting-already-published-versions-is-prevented)
-- [Community files (.github)](#community-files-github)
-- [Dependabot](#dependabot)
+- [Release scenarios](#release-scenarios)
+- [Version overwrite protection](#version-overwrite-protection)
 - [Required setup](#required-setup)
 - [FAQ](#faq)
 
@@ -58,7 +55,7 @@ package binary.
 
 ---
 
-## How MinVer works (your versioning system)
+## How MinVer works
 
 ### Fundamental rule
 
@@ -152,7 +149,7 @@ and are never packaged.
 
 ---
 
-## What you need to do: step-by-step scenarios
+## Release scenarios
 
 ### Scenario 1: Normal development (day to day)
 
@@ -267,9 +264,9 @@ git push
 
 ---
 
-## How overwriting already-published versions is prevented
+## Version overwrite protection
 
-Four layers of protection:
+Six layers of protection:
 
 ### 1. MinVer + height = automatically unique versions
 
@@ -318,8 +315,8 @@ Additional safeguards in the release step:
 
 - **`fail_on_unmatched_files: true`** — the workflow fails if the `.nupkg` glob
   matches no files, preventing an empty release
-- **`make_latest`** — only stable releases are marked as "Latest"; pre-releases
-  are explicitly set to `false`
+- **`prerelease`** — set from the version; GitHub automatically avoids marking
+  pre-releases as "Latest"
 - **`--verify-tag`** — `gh release edit` aborts if the tag does not exist in the
   remote, as an extra safety check
 
@@ -327,30 +324,35 @@ Additional safeguards in the release step:
 
 ## Required setup
 
-### NuGet.org — Trusted Publishing (no stored secret needed)
+### NuGet.org — Trusted Publishing
 
-The release workflow authenticates to NuGet.org via **OIDC Trusted Publishing**.
-GitHub issues a short-lived token unique to each workflow run; NuGet.org verifies
-it against a trusted publisher configuration you define once. No `NUGET_API_KEY`
-secret needs to be stored in the repository.
+The release workflow authenticates to NuGet.org via **OIDC Trusted Publishing**
+using the official [`NuGet/login@v1`](https://github.com/NuGet/login) action.
+GitHub issues a short-lived OIDC token unique to each workflow run; the action
+exchanges it for a temporary NuGet API key.
 
 **One-time setup on NuGet.org:**
 
-1. Go to https://www.nuget.org/account/apikeys
-2. Click **Add new key** → Type: **Trusted Publisher** → **GitHub Actions**
+1. Go to https://www.nuget.org → Sign in → Click your username → **Trusted Publishing**
+2. Click **Add new trusted publishing policy**
 3. Fill in:
-   - Owner: `renzojared`
-   - Repository: `DotEmilu`
-   - Workflow: `publish-release.yml`
+   - Repository Owner: your GitHub username
+   - Repository: your repository name
+   - Workflow: `publish-release.yml` (file name only, without `.github/workflows/`)
    - Environment: `nuget-org`
-4. Save the key (it is not stored anywhere — NuGet uses the OIDC config, not this
-   value)
+4. Save the policy
+
+> If the policy shows "Pending full activation", that is normal for the first
+> 7 days. It becomes permanently active after the first successful publish.
 
 **One-time setup on GitHub:**
 
 1. Go to your repo → **Settings** → **Environments**
 2. Create an environment named exactly **`nuget-org`**
 3. Optionally add protection rules (e.g., require a reviewer before publishing)
+4. Go to **Settings** → **Secrets and variables** → **Actions**
+5. Create a repository secret named **`NUGET_USER`** with your NuGet.org **profile
+   name** (not your email)
 
 ### GitHub Packages
 
@@ -379,104 +381,15 @@ use it automatically.
 Coverage thresholds are configured in [`codecov.yml`](../codecov.yml) (project
 target, patch target, and flag settings). No repository variables are needed.
 
----
+### Quick reference: all settings
 
-## Community files (.github)
-
-GitHub recognizes certain files as "community health files" and displays them in
-the repo UI (Insights → Community tab). Projects adopted by the community
-(Serilog, MediatR, Polly, ASP.NET Core, etc.) include them as standard.
-
-| File | Purpose |
-|---|---|
-| `.github/ISSUE_TEMPLATE/bug_report.yml` | Structured form for reporting bugs |
-| `.github/ISSUE_TEMPLATE/feature_request.yml` | Form for suggesting features |
-| `.github/ISSUE_TEMPLATE/config.yml` | Disables blank issues, adds link to Discussions |
-| `.github/PULL_REQUEST_TEMPLATE.md` | Checklist that appears when opening a PR |
-| `.github/SECURITY.md` | Vulnerability reporting policy |
-| `.github/FUNDING.yml` | "Sponsor" button on GitHub |
-| `.github/dependabot.yml` | Automatic dependency updates |
-| `.github/RELEASE.md` | This guide |
-| `CONTRIBUTING.md` | Contributor guide (build, test, style, conventions) |
-| `CODE_OF_CONDUCT.md` | Code of conduct (Contributor Covenant 2.1) |
-
-### About FUNDING.yml
-
-`FUNDING.yml` activates the **"Sponsor"** button on your GitHub repo. Its current
-content:
-
-```yaml
-github: [renzojared]
-```
-
-This enables GitHub Sponsors for your profile. If you have not configured GitHub
-Sponsors yet, the button will not do anything visible. To activate it:
-
-1. Go to https://github.com/sponsors/renzojared
-2. Follow the onboarding process
-
-If you want to add other donation platforms, you can add more keys:
-
-```yaml
-github: [renzojared]
-# ko_fi: your_username
-# buy_me_a_coffee: your_username
-# custom: ["https://your-site.com/donate"]
-```
-
-It is not mandatory. Many projects only have `github:`.
-
----
-
-## Dependabot
-
-### What is it?
-
-Dependabot is a bot built into GitHub that scans your dependencies and opens
-automatic PRs when updates are available. It does not touch your code — it only
-updates versions in configuration files.
-
-### What does it do in your repo?
-
-Your `dependabot.yml` has two ecosystems configured:
-
-#### 1. `github-actions`
-
-Every Monday it checks whether the actions used in your workflows have new
-versions:
-
-```yaml
-# If actions/checkout@v6.0.2 has a v6.0.3, it opens a PR
-- package-ecosystem: "github-actions"
-  schedule:
-    interval: "weekly"
-    day: "monday"
-```
-
-This is important because GitHub Actions are pinned to specific versions for
-security. Without Dependabot, you would stay on old versions indefinitely.
-
-#### 2. `nuget`
-
-Every Monday it checks your `PackageVersion` entries in `Directory.Packages.props`:
-
-```yaml
-- package-ecosystem: "nuget"
-  groups:
-    ef-core:       # Grouped PRs for Microsoft.EntityFrameworkCore*
-    aspnetcore:    # Grouped PRs for Microsoft.AspNetCore*
-    testing:       # Grouped PRs for xunit*, coverlet*, NSubstitute*, Microsoft.NET.Test.Sdk
-```
-
-The **groups** reduce noise: instead of 5 separate PRs for each EF Core package,
-it opens 1 single PR that updates them all together.
-
-### What do you do?
-
-1. Dependabot opens a PR
-2. CI runs automatically (build + test)
-3. If it passes, review and merge
-4. If it fails, check whether it is a breaking change and decide
+| Setting | Type | Where to configure | Value / Source | Required |
+|---|---|---|---|---|
+| `nuget-org` | Environment | Repo → Settings → Environments | Create with exact name `nuget-org` | **Yes** |
+| `NUGET_USER` | Secret | Repo → Settings → Secrets → Actions | Your NuGet.org profile name | **Yes** |
+| `CODECOV_TOKEN` | Secret | Repo → Settings → Secrets → Actions | From https://app.codecov.io → repo → Settings → Upload Token | Optional (public repos) |
+| `GITHUB_TOKEN` | Secret | Automatic (GitHub provides it) | — | Automatic |
+| Trusted Publishing policy | NuGet.org config | NuGet.org → Account → Trusted Publishing | See [NuGet.org setup](#nugetorg--trusted-publishing) above | **Yes** |
 
 ---
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   DOTNET_NOLOGO: true
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -61,7 +61,7 @@ jobs:
         if: ${{ env.SKIP_PUBLISH != 'true' }}
         run: |
           dotnet nuget push "./nupkgs/*.nupkg" \
-            --source "https://nuget.pkg.github.com/renzojared/index.json" \
+            --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             --api-key ${{ secrets.GITHUB_TOKEN }} \
             --skip-duplicate
 
@@ -71,4 +71,4 @@ jobs:
           echo "### 📦 Pre-release published" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Version:** \`${{ needs.build-and-test.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Registry:** [GitHub Packages](https://github.com/renzojared/DotEmilu/packages)" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Registry:** [GitHub Packages](https://github.com/${{ github.repository }}/packages)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,7 +13,6 @@ concurrency:
 
 env:
   DOTNET_NOLOGO: true
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 permissions: {}   # deny all by default; each job grants only what it needs
@@ -120,8 +119,9 @@ jobs:
     runs-on: ubuntu-latest
 
     # Ties this job to the GitHub Environment configured on NuGet.org as a
-    # trusted publisher. No NUGET_API_KEY secret needed — authentication is
-    # done via a short-lived OIDC token scoped to this exact workflow run.
+    # trusted publisher. Authentication uses a short-lived OIDC token scoped
+    # to this exact workflow run (via NuGet/login@v1).
+    # Required secret: NUGET_USER (your NuGet.org profile name).
     environment: nuget-org
 
     permissions:
@@ -139,49 +139,24 @@ jobs:
         with:
           dotnet-version: '10.x'
 
-      - name: Get NuGet token (Trusted Publishing)
-        id: nuget-token
-        # How this works:
-        # 1. GitHub issues a short-lived OIDC JWT unique to this workflow run.
-        # 2. NuGet.org verifies the JWT against the trusted publisher config
-        #    (owner=renzojared, repo=DotEmilu, workflow=publish-release.yml,
-        #     environment=nuget-org) that you set up in your NuGet account.
-        # 3. NuGet returns a scoped, single-use API key valid only for this run.
-        # 4. The key is masked so it never appears in logs.
-        #
-        # Setup on NuGet.org (one-time):
-        #   Account → API Keys → Add new key → Type: Trusted Publisher
-        #   → GitHub Actions → owner: renzojared, repo: DotEmilu,
-        #     workflow: publish-release.yml, environment: nuget-org
-        run: |
-          OIDC_TOKEN=$(curl -sS \
-            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange" \
-            | jq -r '.value')
-
-          echo "::add-mask::$OIDC_TOKEN"
-
-          API_KEY=$(curl -sS -X POST \
-            "https://www.nuget.org/api/v2/publish/trustedpublisher/oidc" \
-            -H "Content-Type: application/json" \
-            -d "{\"oidcToken\": \"$OIDC_TOKEN\"}" \
-            | jq -r '.apiKey')
-
-          echo "::add-mask::$API_KEY"
-          echo "NUGET_API_KEY=$API_KEY" >> "$GITHUB_ENV"
+      - name: NuGet login (Trusted Publishing)
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
 
       - name: Push .nupkg to NuGet.org
         run: |
           dotnet nuget push "./nupkgs/*.nupkg" \
             --source "https://api.nuget.org/v3/index.json" \
-            --api-key "$NUGET_API_KEY" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --skip-duplicate
 
       - name: Push .snupkg to NuGet.org
         run: |
           dotnet nuget push "./nupkgs/*.snupkg" \
             --source "https://api.nuget.org/v3/index.json" \
-            --api-key "$NUGET_API_KEY" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --skip-duplicate
 
   # ──────────────────────────────────────────────
@@ -211,7 +186,7 @@ jobs:
       - name: Push to GitHub Packages
         run: |
           dotnet nuget push "./nupkgs/*.nupkg" \
-            --source "https://nuget.pkg.github.com/renzojared/index.json" \
+            --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             --api-key ${{ secrets.GITHUB_TOKEN }} \
             --skip-duplicate
 
@@ -246,9 +221,9 @@ jobs:
         run: |
           VERSION="${{ needs.build.outputs.version }}"
           if echo "$VERSION" | grep -q '-'; then
-            PACKAGE_REGISTRY_TEXT="📦 [GitHub Packages](https://github.com/renzojared/DotEmilu/packages)"
+            PACKAGE_REGISTRY_TEXT="📦 [GitHub Packages](https://github.com/${{ github.repository }}/packages)"
           else
-            PACKAGE_REGISTRY_TEXT="📦 [NuGet.org packages](https://www.nuget.org/profiles/renzojared)"
+            PACKAGE_REGISTRY_TEXT="📦 [NuGet.org packages](https://www.nuget.org/profiles/${{ secrets.NUGET_USER }})"
           fi
 
           {


### PR DESCRIPTION
## Description

Replaces the manual OIDC token-exchange script in the release workflow with the
official `NuGet/login@v1` action, removes hardcoded owner/repo references, drops
the deprecated `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` variable, and updates RELEASE.md
to reflect the new setup flow.

Closes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Build / CI change

## Checklist

- [x] My code follows the existing code style
- [x] I have run `dotnet build DotEmilu.slnx -c Release` with no warnings
- [ ] I have added/updated tests that prove my fix or feature works
- [x] All tests pass locally (`dotnet test --solution DotEmilu.slnx -c Release`)
- [x] I have updated documentation if needed (README, XML docs, guides)
